### PR TITLE
Remove batchSequenceNumber

### DIFF
--- a/lib/file/index.js
+++ b/lib/file/index.js
@@ -4,8 +4,6 @@ var _ = require('lodash');
 var async = require('async');
 var utils = require('../utils');
 var validate = require('../validate');
-
-var batchSequenceNumber = 0
 var highLevelOverrides = ['immediateDestination','immediateOrigin','fileCreationDate','fileCreationTime','fileIdModifier','immediateDestinationName','immediateOriginName','referenceCode'];
 
 function File(options) {
@@ -22,8 +20,10 @@ function File(options) {
     if(options.immediateDestination) {
         this.header.immediateDestination.value = utils.computeCheckDigit(options.immediateDestination);
     }
-    
-	// Validate all values 
+
+	this._batchSequenceNumber = Number(options.batchSequenceNumber) || 0
+
+	// Validate all values
 	this._validate();
 	
 	return this;
@@ -73,12 +73,12 @@ File.prototype._validate = function() {
 File.prototype.addBatch = function(batch) {
 	
 	// Set the batch number on the header and control records
-	batch.header.batchNumber.value = batchSequenceNumber
-	batch.control.batchNumber.value = batchSequenceNumber
+	batch.header.batchNumber.value = this._batchSequenceNumber
+	batch.control.batchNumber.value = this._batchSequenceNumber
 
 	// Increment the batchSequenceNumber
-	++batchSequenceNumber
-	
+	++this._batchSequenceNumber
+
 	this._batches.push(batch);
 };
 


### PR DESCRIPTION
With this PR the file generation can be idempotent, ie, it's is possible to create several `File` objects with the same setup and each will have the same content. This is most relevant in tests .
