### PR TITLE
Fix file and batch entryhash truncate

### DIFF
--- a/lib/batch/index.js
+++ b/lib/batch/index.js
@@ -111,8 +111,8 @@ Batch.prototype.addEntry = function(entry) {
 		self.control.totalCredit.value = totalCredit;
 		self.control.totalDebit.value = totalDebit;
 
-		// Add up the positions 4-11 and compute the total
-		self.control.entryHash.value = entryHash.toString().slice(0, 10);
+		// Add up the positions 4-11 and compute the total. Slice the 10 rightmost digits.
+		self.control.entryHash.value = entryHash.toString().slice(-10);
 	});
 };
 

--- a/lib/file/index.js
+++ b/lib/file/index.js
@@ -144,9 +144,10 @@ File.prototype.generateBatches = function(done1) {
 
 		self.control.addendaCount.value = addendaCount;
         self.control.blockCount.value = utils.getNextMultiple(rows, 10) / 10;
-		
-		self.control.entryHash.value = entryHash.toString().slice(0,10);
-        
+
+		// Slice the 10 rightmost digits.
+		self.control.entryHash.value = entryHash.toString().slice(-10);
+
         // Pass the result string as well as the number of rows back
         done1(result, rows);
 	});


### PR DESCRIPTION
This PR fixes the truncation of the of the entry hash that we compute for batch and file controls. If this value if larger than 10 characters, it must be truncated, to properly fit its space in the control field. This may happen for large files, where the sum of all the entry hash fields, generate a total sum that may exceed the 10 characters limitation. 

So, we need to select only the 10 rightmost characters, instead of the leftmost 10, like we had.