### PR TITLE
Fix two bugs when providing options to new File() and new Batch()

### DIFF
--- a/lib/batch/index.js
+++ b/lib/batch/index.js
@@ -12,8 +12,8 @@ function Batch(options) {
 	this._entries = [];
 
 	// Allow the batch header/control defaults to be overriden if provided
-	this.header = options.header ? _.merge(options.header, require('./header'), _.defaults) : _.cloneDeep(require('./header'));
-	this.control = options.control ? _.merge(options.header, require('./control'), _.defaults) : _.cloneDeep(require('./control'));
+	this.header = options.header ? _.defaultsDeep({}, options.header, require('./header')) : _.cloneDeep(require('./header'));
+	this.control = options.control ? _.defaultsDeep({}, options.control, require('./control')) : _.cloneDeep(require('./control'));
 
 	// Configure high-level overrides (these override the low-level settings if provided)
 	utils.overrideLowLevel(highLevelHeaderOverrides, options, this);

--- a/lib/file/index.js
+++ b/lib/file/index.js
@@ -10,8 +10,8 @@ function File(options) {
 	this._batches = [];
 
 	// Allow the batch header/control defaults to be overriden if provided
-	this.header = options.header ? _.merge(options.header, require('./header')(), _.defaults) : require('./header')();
-	this.control = options.control ? _.merge(options.header, require('./control'), _.defaults) : _.cloneDeep(require('./control'));
+	this.header = options.header ? _.defaultsDeep({}, options.header, require('./header')()) : require('./header')();
+	this.control = options.control ? _.defaultsDeep({}, options.control, require('./control')) : _.cloneDeep(require('./control'));
 
 	// Configure high-level overrides (these override the low-level settings if provided)
 	utils.overrideLowLevel(highLevelOverrides, options, this);


### PR DESCRIPTION
Hey there, we're using this for a banking partner that has an alphanumeric (instead of numeric) immediateOrigin value and company ID value. I went to override these values in the schema by using the `options.header` and `options.control` values in File and Batch but discovered a couple of bugs there.

Essentially my code looked like this:
```javascript
const FILE_OPTS = {
  file: {
    header: {
      immediateOrigin: { type: "alphanumeric" },
      // ... other header settings
    }
  },
  batch: {
    header: {
      //... header settings
    },
    control: {
      //... control settings
    }
  }
}

let file = new File(FILE_OPTS.file);
let batch = new Batch(FILE_OPTS.batch);
```

First, that since the code was using `_.merge`, the default settings overwrote the ones I passed in, so the type of immediate origin ended up staying as "numeric".
Second, `_.merge` mutates its input, so my FILE_OPTS constants were changed to the nACH2 defaults.
Third, the code in batch/index.js was using the "header" setting for the control options.

I fixed that in our fork by using `_.defaultsDeep` instead of `_.merge`, providing a new empty object to avoid mutating whatever the user has passed in to the constructor, and corrected the typo in the batch options setting to use options.control.