### PR TITLE
Create new method on Batch granting control over count/sum updates.

### DIFF
--- a/lib/batch/index.js
+++ b/lib/batch/index.js
@@ -85,7 +85,9 @@ Batch.prototype.addEntry = function(entry) {
 
 	// Add the new entry to the entries array
 	this._entries.push(entry);
+};
 
+Batch.prototype.updateBatchValues = function() {
 	// Update the batch values like total debit and credit $ amounts
 	var entryHash = 0;
 	var totalDebit = 0;

--- a/lib/file/index.js
+++ b/lib/file/index.js
@@ -105,7 +105,8 @@ File.prototype.generateBatches = function(done1) {
 	var totalDebit = 0;
 	var totalCredit = 0;
 
-	async.each(this._batches, function(batch, done2) {	
+	async.each(this._batches, function(batch, done2) {
+	        batch.updateBatchValues();
 		totalDebit += batch.control.totalDebit.value;
 		totalCredit += batch.control.totalCredit.value;
         


### PR DESCRIPTION
Previously, performance when adding many entries to the same batch could become quite poor, and some users only need batches counts and totals up to date at the time of rendering the NACHA file. With this new method, users who need constant batch counts and totals updated can still call updateBatchValues() after every addEntry() and those who don't can enjoy much improved file generation time.