### PR TITLE
specify the license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "file",
     "Automated Clearing House"
   ],
+  "license": "MIT",
   "contributors": [
     {
       "name": "Glen Selle",


### PR DESCRIPTION
This is to make it match the license specified in the README.