### PR TITLE
[Issue-41] - Fix Batch Control Override and Update Company Identification to Alphanumeric

### DIFF
--- a/lib/batch/control.js
+++ b/lib/batch/control.js
@@ -60,7 +60,7 @@ module.exports = {
 		width: 10,
 		position: 7,
 		required: true,
-		type: 'numeric'
+		type: 'alphanumeric'
 	},
 
 	messageAuthenticationCode: {

--- a/lib/batch/header.js
+++ b/lib/batch/header.js
@@ -41,7 +41,7 @@ module.exports = {
 		width: 10,
 		position: 5,
 		required: true,
-		type: 'numeric',
+		type: 'alphanumeric',
 		value: ''
 	},
 

--- a/lib/batch/index.js
+++ b/lib/batch/index.js
@@ -13,7 +13,7 @@ function Batch(options) {
 
 	// Allow the batch header/control defaults to be overriden if provided
 	this.header = options.header ? _.merge(options.header, require('./header'), _.defaults) : _.cloneDeep(require('./header'));
-	this.control = options.control ? _.merge(options.header, require('./control'), _.defaults) : _.cloneDeep(require('./control'));
+	this.control = options.control ? _.merge(options.control, require('./control'), _.defaults) : _.cloneDeep(require('./control'));
 
 	// Configure high-level overrides (these override the low-level settings if provided)
 	utils.overrideLowLevel(highLevelHeaderOverrides, options, this);


### PR DESCRIPTION
**Issue**: [#41](https://github.com/glenselle/nACH2/issues/41)

### Overview:
This PR resolves two key issues:
1. **Batch Control Override Fix**: Corrects the batch control override logic.
2. **Company Identification Update**: Updates the `companyIdentification` field to support `alphanumeric` values, in line with modern NACHA practices that allow for greater flexibility.

### Details:
- The **NACHA Company Identification field** was originally designed to be `numeric`, often using the Employer Identification Number (EIN) prefixed with a "1". However, as ACH payments expanded and proprietary codes became more common, financial institutions started to support alphanumeric Company IDs. This change accommodates different identification schemes, making it easier for various types of originators to comply.
  
### Changes:
- **Batch Control Fix**: Fix batch control override logic.
- **Company ID Update**: Adjusted the type for `companyIdentification` field to allow `alphanumeric` characters, reflecting current standards.

Please review and merge if appropriate! :) 